### PR TITLE
Update DreamPyLib API to only require the API key (no user), use more Pythonic variable naming (as per PEP-8), other small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,84 @@
-Dreampylib 1.0
-==============
+# DreamPyLib
 
-A python library for interacting with Dreamhost's API
-Dreampylib 1.0
+## Introduction
 
-License
-=======
-This version is based on work by Laurens Simonis which originally carried this license:
+This is a Python library for interacting with DreamHost's API. It is based on the [work of Laurens Simonis](http://dreampylib.laurenssimonis.com/). Also included are some basic sample scripts which use the library.
 
-"Dreampylib is (c) 2009 by Laurens Simonis.
-Use it at your own risk, do with it whatever you like, 
-but I am not responsible for whatever you do with it."
+## Installation
 
-In the spirit of 'do with it whatever you like' it was put on github under an MIT license
-May 7 2004
+To install, clone this repo and then run the `setup.py` installation script:
+
+~~~
+git clone https://github.com/EliRibble/dreampylib.git
+cd dreampylib
+python setup.py install
+~~~
+
+Alternatively, if you just want to install for the current user or don't have permissions to install in the site-packages or dist-packages directory, simply use
+
+`python setup.py install --user`
+
+instead.
+
+## Usage
+
+The original author's [manual](http://dreampylib.laurenssimonis.com/?page_id=7) still mostly applies, but some of the function names have changed to a more pythonic style (i.e. lower-case with underscore separators), and a `user` is no longer needed for API access. See the `dreampylib/example.py` file for a simple example. The basic usage is outlined here, as well.
+
+### Initialization
+
+Either initialize the DreampyLib object with the API key to connect on construction:
+
+~~~python
+import dreampylib
+
+key = '6SHU5P2HLDAYECUM'
+connection = dreampylib.DreampyLib(key)
+~~~
+
+or initialize without the key to postpone connection:
+
+~~~python
+connection = dreampylib.DreampyLib()
+connection.connect(key)
+~~~
+.
+
+### Inspecting the connection
+
+To verify the connection was established and check the status of the previous API call:
+
+~~~python
+if not connection.is_connected():
+	print("Error connecting!")
+	print(connection.status())
+	return
+~~~
+
+### Checking available commands
+
+Each API key is given access to a specific set of API functions for that user. The following lists the available commands for the given API key:
+
+~~~python
+print('Available commands:\n ')
+commands = connection.available_commands()
+command_names = [command[0] for command in commands]
+print('\n'.join(command_names))
+~~~
+
+### DreamHost API calls
+
+The DreamHost API [documentation](https://help.dreamhost.com/hc/en-us/sections/203903178-API-Application-Programming-Interface-) gives an outline of the available API commands, expected parameters, and return values. Each category of API calls (e.g. `dns`) has an associated set of functions (e.g. `list_records`). These are of the form `category-function` (e.g. `dns-list_records`). To use these functions with DreampyLib, the `connection` is invoked using an attribute syntax: `connection.category.function(**kwargs)` (e.g. `connection.dns.list_records()`), where `**kwargs` are the named arguments for the API function call.
+
+The return value of these API calls take the form of a tuple with three values:
+
+`success, msg, body = connection.category.function(**kwargs)`
+
+where `success` is a boolean, `msg` is a string containing either `'success'` or the error message, and `body` is the actual content of the API function call return value. The default type of `body` is a list of dictionaries with keys being the names of the table columns. To view the results of a previous call as a list of lists instead, use `connection.result_list()`. Similarly, the functions `connection.result_dict()` and `connection.result_keys()` exist for obtaining the previous call's list of dictionaries and associated keys.
+
+## License
+
+The work by Laurens Simonis originally carried this license:
+
+> Dreampylib is (c) 2009 by Laurens Simonis. Use it at your own risk, do with it whatever you like, but I am not responsible for whatever you do with it.
+
+In the spirit of 'do with it whatever you like', it was put on github under an MIT license on May 7 2014.

--- a/dreampylib/__init__.py
+++ b/dreampylib/__init__.py
@@ -12,7 +12,6 @@ class _RemoteCommand(object):
     # some magic to catch arbitrary maybe non-existent func. calls
     # supports "nested" methods (e.g. examples.getStateName)
     def __init__(self, name, parent, url):
-        
         # Store the name of the 
         self._name = name
         self._cmd  = name.replace('.','-')
@@ -20,12 +19,11 @@ class _RemoteCommand(object):
         self._url = url
         self._child = None
         
-        self._resultKeys = []
+        self._result_keys = []
         self._status = ""
-        self._resultDict = []
-        self._resultList = []
+        self._result_dict = []
+        self._result_list = []
         
-    
     def status(self):
         if self._child:
             return self._child.status()
@@ -36,29 +34,28 @@ class _RemoteCommand(object):
         if self._child:
             return self._child.result_keys()
         else:
-            return self._resultKeys
+            return self._result_keys
         
     def result_list(self):
         if self._child:
             return self._child.result_list()
         else:
-            return self._resultList
+            return self._result_list
         
     def result_dict(self):
         if self._child:
             return self._child.result_dict()
         else:
-            return self._resultDict
+            return self._result_dict
     
     def __getattr__(self, name):
         self._child = _RemoteCommand("%s.%s" % (self._name, name), self._parent, self._url)
         return self._child
     
-    def __call__(self, returnType = None, *args, **kwargs):
+    def __call__(self, return_type=None, *args, **kwargs):
         LOGGER.debug("Called %s(%s)", self._name, str(kwargs))
         
         if self._parent.is_connected():
-        
             request = {}
             request.update(kwargs)
             request.update(self._parent._get_user_data())
@@ -69,32 +66,32 @@ class _RemoteCommand(object):
             LOGGER.debug("Request: %s", request)
                 
             self._connection = urllib2.urlopen(self._url, urllib.urlencode(request))
-            return self._parse_result(returnType)
+            return self._parse_result(return_type)
         else:
             return []
         
-    def _parse_result(self, returnType):
+    def _parse_result(self, return_type):
         '''Parse the result of the request'''
         lines = [l.strip() for l in self._connection.readlines()]
         
         self._status = lines[0]
         
         if self._status == 'success':
-            self._resultKeys = keys = lines[1].split('\t')
+            self._result_keys = keys = lines[1].split('\t')
             
             table = []
             for resultLine in lines[2:]:
                     values = resultLine.split('\t')
-                    self._resultDict.append(dict(zip(keys,values)))
+                    self._result_dict.append(dict(zip(keys,values)))
                     if len(values) == 1:
-                        self._resultList.append(values[0])
+                        self._result_list.append(values[0])
                     else:
-                        self._resultList.append(values)
+                        self._result_list.append(values)
             
-            if returnType == 'list':
-                table = self._resultList
+            if return_type == 'list':
+                table = self._result_list
             else:
-                table = self._resultDict
+                table = self._result_dict
             
             LOGGER.debug("Table: %s", table)
                     
@@ -107,76 +104,67 @@ class _RemoteCommand(object):
         
 class DreampyLib(object):
     
-    def __init__(self, user=None, key=None, url = 'https://api.dreamhost.com'):
+    def __init__(self, key=None, url='https://api.dreamhost.com'):
         '''Initialises the connection to the dreamhost API.'''
-        
-        self._user = user
         self._key = key
         self._url = url
-        self._lastCommand = None
+        self._last_command = None
         self._connected = False
-        self._availableCommands = []
+        self._available_commands = []
         
-        if user and key:
+        if key:
             self.connect()
 
     
-    def connect(self, user = None, key = None, url = None):
-        if user:
-            self._user = user
-            
+    def connect(self, key=None, url=None):
         if key:
             self._key = key
-            
         if url:
             self._url = url
-            
+
         self._connected = True
-        self._availableCommands = self.api.list_accessible_cmds(returnType = 'list')
-        self._connected = True if self._availableCommands[0] != False else False
+        self._connected, _, self._available_commands = self.api.list_accessible_cmds(return_type='list')
         if not self._connected:
-            self._availableCommands = []
+            self._available_commands = []
             return False
         return True
         
     def available_commands(self):
-        return self._availableCommands
+        return self._available_commands
     
     def is_connected(self):
         return self._connected
      
     def result_keys(self):
-        if not self._lastCommand:
+        if not self._last_command:
             return []
         else:
-            return self._lastCommand.result_keys()
+            return self._last_command.result_keys()
         
     def result_list(self):
-        if not self._lastCommand:
+        if not self._last_command:
             return []
         else:
-            return self._lastCommand.result_list()
+            return self._last_command.result_list()
         
     def result_dict(self):
-        if not self._lastCommand:
+        if not self._last_command:
             return []
         else:
-            return self._lastCommand.result_dict()
+            return self._last_command.result_dict()
         
     def status(self):
-        if not self._lastCommand:
+        if not self._last_command:
             return None
         else:
-            return self._lastCommand.status()
+            return self._last_command.status()
         
     def _get_user_data(self):
-        return {    'username':  self._user,
-                    'key':       self._key,
-                }
+        return {'key': self._key}
     
-    def __getattr__(self,name):
-        self._lastCommand = _RemoteCommand(name, self, self._url)
-        return self._lastCommand
+    def __getattr__(self, name):
+        self._last_command = _RemoteCommand(name, self, self._url)
+        return self._last_command
         
     def dir(self):
-        self.api.list_accessible_cmds()
+        return self.api.list_accessible_cmds(return_type='list')[-1]

--- a/dreampylib/example.py
+++ b/dreampylib/example.py
@@ -6,12 +6,11 @@ import dreampylib
 
 def main():
 
-    # Dreamhost test API account:
-    user = 'apitest@dreamhost.com'
-    key  = '6SHU5P2HLDAYECUM'
+    # DreamHost test API:
+    key = '6SHU5P2HLDAYECUM'
 
     # Initialize the library and open a connection
-    connection = dreampylib.DreampyLib(user,key)
+    connection = dreampylib.DreampyLib(key)
        
     # If the connection is up, do some tests.
     if not connection.is_connected():
@@ -23,15 +22,20 @@ def main():
     print('Available commands:\n ')
     commands = connection.available_commands()
     command_names = [command[0] for command in commands]
-    print('\n  '.join(command_names))
+    print('\n'.join(command_names))
+
+    success, msg, body = connection.announcement_list.list_lists()
+    if not success:
+        raise Exception("Failed to list announcement lists.")
+    print(body)
+
+    for announcement_list in body:
+        if int(announcement_list['num_subscribers']) < 200:
+            connection.announcement_list.list_subscribers(listname=announcement_list['listname'], domain=announcement_list['domain'])
+            print(connection.result_list())
     
-    print(connection.dreamhost_ps.list_ps())
-    
-    connection.dreamhost_ps.list_size_history(ps = 'ps7093')
-    print(connection.result_list())
-    
-    # Let's also print(the keys so we know what we're looking at
-    print(connection.result_keys())
+            # Let's also print(the keys so we know what we're looking at
+            print(connection.result_keys())
 
 if __name__ == '__main__':
     main()

--- a/scripts/list_commands
+++ b/scripts/list_commands
@@ -5,11 +5,10 @@ import pprint
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('user', help='Your dreamhost user')
     parser.add_argument('apikey', help='Your dreamhost API key')
     args = parser.parse_args()
 
-    connection = dreampylib.DreampyLib(args.user, args.apikey)
+    connection = dreampylib.DreampyLib(args.apikey)
     if not connection.is_connected():
         raise Exception("Unable to connect")
 

--- a/scripts/update_my_dns
+++ b/scripts/update_my_dns
@@ -11,7 +11,6 @@ def main():
     logging.basicConfig()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('user', help='Your dreamhost user')
     parser.add_argument('apikey', help='Your dreamhost API key')
     parser.add_argument('record', help='The record to add/update')
     parser.add_argument('type', choices=['A', 'CNAME', 'NS', 'PTR', 'NAPTR', 'SRV', 'TXT', 'SPF', 'AAAA'], help="The type of DNS entry to record")
@@ -33,7 +32,7 @@ def main():
         args.value = result.text.strip()
         LOGGER.info("Using IP address from ifconfig.me: %s", args.value)
 
-    connection = dreampylib.DreampyLib(args.user, args.apikey)
+    connection = dreampylib.DreampyLib(args.apikey)
     if not connection.is_connected():
         raise Exception("Unable to connect")
 


### PR DESCRIPTION
* README.md: Include installation and usage instructions; correct the date of MIT licensing to May 7 2014
* dreampylib/\_\_init\_\_.py: Use Pythonic variable names
* dreampylib/\_\_init\_\_.py: Remove user from DreampyLib object
* dreampylib/\_\_init\_\_.py: Simplify connect() method by assigning the individual tuple values
* dreampylib/\_\_init\_\_.py: Return only the body of the API accessible commands in the dir() method
* dreampylib/example.py: Remove user
* dreampylib/example.py: Update example to demonstrate announcement_list category API in a somewhat realistic way since the VPS API is no longer available as of November 30 2015
* scripts/list_commands: Remove user
* scripts/update_my_dns: Remove user